### PR TITLE
Feat: added target => namespace support + ECS compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+## 1.1.0
+  - Feat: added target => namespace support + ECS compatibility [#7](https://github.com/logstash-plugins/logstash-codec-csv/pull/7)
+
 ## 1.0.0
   - Fixed dependencies to work with logstash v6 and up. Overhauled to match features of the CSV Filter. Improved spec coverage [#4](https://github.com/logstash-plugins/logstash-codec-csv/pull/4)
+
 ## 0.1.5
   - Fixed asciidoc formatting for example [#3](https://github.com/logstash-plugins/logstash-codec-csv/pull/3)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -33,10 +33,12 @@ The csv codec takes CSV data, parses it and passes it along.
 | <<plugins-{type}s-{plugin}-charset>> |<<string,string>>, one of `["ASCII-8BIT", "UTF-8", "US-ASCII", "Big5", "Big5-HKSCS", "Big5-UAO", "CP949", "Emacs-Mule", "EUC-JP", "EUC-KR", "EUC-TW", "GB2312", "GB18030", "GBK", "ISO-8859-1", "ISO-8859-2", "ISO-8859-3", "ISO-8859-4", "ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8", "ISO-8859-9", "ISO-8859-10", "ISO-8859-11", "ISO-8859-13", "ISO-8859-14", "ISO-8859-15", "ISO-8859-16", "KOI8-R", "KOI8-U", "Shift_JIS", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE", "Windows-31J", "Windows-1250", "Windows-1251", "Windows-1252", "IBM437", "IBM737", "IBM775", "CP850", "IBM852", "CP852", "IBM855", "CP855", "IBM857", "IBM860", "IBM861", "IBM862", "IBM863", "IBM864", "IBM865", "IBM866", "IBM869", "Windows-1258", "GB1988", "macCentEuro", "macCroatian", "macCyrillic", "macGreek", "macIceland", "macRoman", "macRomania", "macThai", "macTurkish", "macUkraine", "CP950", "CP951", "IBM037", "stateless-ISO-2022-JP", "eucJP-ms", "CP51932", "EUC-JIS-2004", "GB12345", "ISO-2022-JP", "ISO-2022-JP-2", "CP50220", "CP50221", "Windows-1256", "Windows-1253", "Windows-1255", "Windows-1254", "TIS-620", "Windows-874", "Windows-1257", "MacJapanese", "UTF-7", "UTF8-MAC", "UTF-16", "UTF-32", "UTF8-DoCoMo", "SJIS-DoCoMo", "UTF8-KDDI", "SJIS-KDDI", "ISO-2022-JP-KDDI", "stateless-ISO-2022-JP-KDDI", "UTF8-SoftBank", "SJIS-SoftBank", "BINARY", "CP437", "CP737", "CP775", "IBM850", "CP857", "CP860", "CP861", "CP862", "CP863", "CP864", "CP865", "CP866", "CP869", "CP1258", "Big5-HKSCS:2008", "ebcdic-cp-us", "eucJP", "euc-jp-ms", "EUC-JISX0213", "eucKR", "eucTW", "EUC-CN", "eucCN", "CP936", "ISO2022-JP", "ISO2022-JP2", "ISO8859-1", "ISO8859-2", "ISO8859-3", "ISO8859-4", "ISO8859-5", "ISO8859-6", "CP1256", "ISO8859-7", "CP1253", "ISO8859-8", "CP1255", "ISO8859-9", "CP1254", "ISO8859-10", "ISO8859-11", "CP874", "ISO8859-13", "CP1257", "ISO8859-14", "ISO8859-15", "ISO8859-16", "CP878", "MacJapan", "ASCII", "ANSI_X3.4-1968", "646", "CP65000", "CP65001", "UTF-8-MAC", "UTF-8-HFS", "UCS-2BE", "UCS-4BE", "UCS-4LE", "CP932", "csWindows31J", "SJIS", "PCK", "CP1250", "CP1251", "CP1252", "external", "locale"]`|No
 | <<plugins-{type}s-{plugin}-columns>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-convert>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-include_headers>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-quote_char>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-separator>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-skip_empty_columns>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 |=======================================================================
 
 &nbsp;
@@ -102,6 +104,19 @@ Possible conversions are: `integer`, `float`, `date`, `date_time`, `boolean`
       }
     }
 
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: CSV data added at root level
+    ** `v1`,`v8`: Elastic Common Schema compliant behavior (`[event][original]` is also added)
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+
 [id="plugins-{type}s-{plugin}-include_headers"]
 ===== `include_headers` 
 
@@ -139,5 +154,25 @@ Optional.
 
 Define whether empty columns should be skipped.
 Defaults to false. If set to true, columns containing no value will not be included.
+
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Define the target field for placing the row values. If this setting is not
+set, the CSV data will be stored at the root (top level) of the event.
+
+For example, if you want data to be put under the `document` field:
+[source,ruby]
+    input {
+      file {
+        codec => csv {
+          autodetect_column_names => true
+          target => "[document]"
+        }
+      }
+    }
 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -22,8 +22,15 @@ include::{include_path}/plugin_header.asciidoc[]
 
 The csv codec takes CSV data, parses it and passes it along.
 
+[id="plugins-{type}s-{plugin}-ecs"]
+==== Compatibility with the Elastic Common Schema (ECS)
+
+The plugin behaves the same regardless of ECS compatibility, except giving a warning when ECS is enabled and `target` isn't set.
+
+TIP: Set the `target` option to avoid potential schema conflicts.
+
 [id="plugins-{type}s-{plugin}-options"]
-==== Csv Codec Configuration Options
+==== Csv Codec configuration options
 
 [cols="<,<,<",options="header",]
 |=======================================================================

--- a/lib/logstash/codecs/csv.rb
+++ b/lib/logstash/codecs/csv.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/codecs/base"
 require "logstash/util/charset"
+require "logstash/event"
 
 require 'logstash/plugin_mixins/ecs_compatibility_support'
 require 'logstash/plugin_mixins/ecs_compatibility_support/target_check'

--- a/lib/logstash/codecs/csv.rb
+++ b/lib/logstash/codecs/csv.rb
@@ -138,11 +138,11 @@ class LogStash::Codecs::CSV < LogStash::Codecs::Base
       end
 
       decoded = {}
-      values.each_index do |i|
-        unless (@skip_empty_columns && (values[i].nil? || values[i].empty?))
+      values.each_with_index do |value, i|
+        unless (@skip_empty_columns && (value.nil? || value.empty?))
           unless ignore_field?(i)
             field_name = @columns[i] || "column#{i + 1}"
-            decoded[field_name] = transform(field_name, values[i])
+            decoded[field_name] = transform(field_name, value)
           end
         end
       end

--- a/lib/logstash/codecs/csv.rb
+++ b/lib/logstash/codecs/csv.rb
@@ -118,12 +118,10 @@ class LogStash::Codecs::CSV < LogStash::Codecs::Base
     raise(LogStash::ConfigurationError, "Invalid conversion types: #{bad_types.join(', ')}") unless bad_types.empty?
 
     # @convert_symbols contains the symbolized types to avoid symbol conversion in the transform method
-    @convert_symbols = @convert.each_with_object({}){|(k, v), result| result[k] = v.to_sym}
+    @convert_symbols = @convert.each_with_object({}) { |(k, v), result| result[k] = v.to_sym }
 
     # if the zero byte character is entered in the config, set the value
-    if (@quote_char == "\\x00")
-      @quote_char = "\x00"
-    end
+    @quote_char = "\x00" if @quote_char == "\\x00"
 
     @logger.debug? && @logger.debug("CSV parsing options", :col_sep => @separator, :quote_char => @quote_char)
   end

--- a/logstash-codec-csv.gemspec
+++ b/logstash-codec-csv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-csv'
-  s.version         = '1.0.0'
+  s.version         = '1.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The csv codec take CSV data, parses it and passes it away"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-codec-csv.gemspec
+++ b/logstash-codec-csv.gemspec
@@ -21,6 +21,9 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
+  s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/spec/codecs/csv_spec.rb
+++ b/spec/codecs/csv_spec.rb
@@ -19,6 +19,8 @@ describe LogStash::Codecs::CSV, :ecs_compatibility_support do
 
     ecs_compatibility_matrix(:disabled, :v1, :v8 => :v1) do |ecs_select|
 
+      let(:config) { super().merge('ecs_compatibility' => ecs_select.active_mode.to_s) }
+
       it "return an event from CSV data" do
         event_count = 0
         codec.decode(data) do |event|
@@ -198,7 +200,7 @@ describe LogStash::Codecs::CSV, :ecs_compatibility_support do
 
       context "with target" do
 
-        let(:config) { super().merge('target' => '[csv-root]', 'ecs_compatibility' => ecs_select.active_mode.to_s) }
+        let(:config) { super().merge('target' => '[csv-root]') }
 
         it "return an event from CSV data" do
           event_count = 0

--- a/spec/codecs/csv_spec.rb
+++ b/spec/codecs/csv_spec.rb
@@ -1,8 +1,9 @@
 # encoding: utf-8
 require "logstash/codecs/csv"
 require "logstash/event"
+require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 
-describe LogStash::Codecs::CSV do
+describe LogStash::Codecs::CSV, :ecs_compatibility_support do
 
   subject(:codec) { LogStash::Codecs::CSV.new(config) }
   let(:config)    { Hash.new }
@@ -12,181 +13,219 @@ describe LogStash::Codecs::CSV do
   end
 
   describe "decode" do
+
     let(:data) { "big,bird,sesame street" }
 
-    it "return an event from CSV data" do
-      codec.decode(data) do |event|
-        expect(event.get("column1")).to eq("big")
-        expect(event.get("column2")).to eq("bird")
-        expect(event.get("column3")).to eq("sesame street")
-      end
-    end
+    ecs_compatibility_matrix(:disabled, :v1, :v8 => :v1) do |ecs_select|
 
-    describe "given column names" do
-      let(:doc)    { "big,bird,sesame street" }
-      let(:config) do
-        { "columns" => ["first", "last", "address" ] }
-      end
-
-      it "extract all the values" do
-        codec.decode(data) do |event|
-          expect(event.get("first")).to eq("big")
-          expect(event.get("last")).to eq("bird")
-          expect(event.get("address")).to eq("sesame street")
-        end
-      end
-
-      context "parse csv skipping empty columns" do
-
-        let(:data)    { "val1,,val3" }
-
-        let(:config) do
-          { "skip_empty_columns" => true,
-            "columns" => ["custom1", "custom2", "custom3"] }
-        end
-
-        it "extract all the values" do
-          codec.decode(data) do |event|
-            expect(event.get("custom1")).to eq("val1")
-            expect(event.to_hash).not_to include("custom2")
-            expect(event.get("custom3")).to eq("val3")
-          end
-        end
-      end
-
-      context "parse csv without autogeneration of names" do
-
-        let(:data)    { "val1,val2,val3" }
-        let(:config) do
-          {  "autogenerate_column_names" => false,
-             "columns" => ["custom1", "custom2"] }
-        end
-
-        it "extract all the values" do
-          codec.decode(data) do |event|
-            expect(event.get("custom1")).to eq("val1")
-            expect(event.get("custom2")).to eq("val2")
-            expect(event.get("column3")).to be_falsey
-          end
-        end
-      end
-
-    end
-
-    describe "custom separator" do
-      let(:data) { "big,bird;sesame street" }
-
-      let(:config) do
-        { "separator" => ";" }
-      end
+      # before(:each) do
+      #   allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
+      # end
 
       it "return an event from CSV data" do
+        event_count = 0
         codec.decode(data) do |event|
-          expect(event.get("column1")).to eq("big,bird")
-          expect(event.get("column2")).to eq("sesame street")
-        end
-      end
-    end
-
-    describe "quote char" do
-      let(:data) { "big,bird,'sesame street'" }
-
-      let(:config) do
-        { "quote_char" => "'"}
-      end
-
-      it "return an event from CSV data" do
-        codec.decode(data) do |event|
+          event_count += 1
           expect(event.get("column1")).to eq("big")
           expect(event.get("column2")).to eq("bird")
           expect(event.get("column3")).to eq("sesame street")
         end
+        expect( event_count ).to eql 1
       end
 
-      context "using the default one" do
-        let(:data) { 'big,bird,"sesame, street"' }
-        let(:config) { Hash.new }
+      describe "given column names" do
+        let(:doc)    { "big,bird,sesame street" }
+        let(:config) do
+          { "columns" => ["first", "last", "address" ] }
+        end
+
+        it "extract all the values" do
+          codec.decode(data) do |event|
+            expect(event.get("first")).to eq("big")
+            expect(event.get("last")).to eq("bird")
+            expect(event.get("address")).to eq("sesame street")
+          end
+        end
+
+        context "parse csv skipping empty columns" do
+
+          let(:data)    { "val1,,val3" }
+
+          let(:config) do
+            { "skip_empty_columns" => true,
+              "columns" => ["custom1", "custom2", "custom3"] }
+          end
+
+          it "extract all the values" do
+            codec.decode(data) do |event|
+              expect(event.get("custom1")).to eq("val1")
+              expect(event.to_hash).not_to include("custom2")
+              expect(event.get("custom3")).to eq("val3")
+            end
+          end
+        end
+
+        context "parse csv without autogeneration of names" do
+
+          let(:data)    { "val1,val2,val3" }
+          let(:config) do
+            {  "autogenerate_column_names" => false,
+               "columns" => ["custom1", "custom2"] }
+          end
+
+          it "extract all the values" do
+            codec.decode(data) do |event|
+              expect(event.get("custom1")).to eq("val1")
+              expect(event.get("custom2")).to eq("val2")
+              expect(event.get("column3")).to be_falsey
+            end
+          end
+        end
+
+      end
+
+      describe "custom separator" do
+        let(:data) { "big,bird;sesame street" }
+
+        let(:config) do
+          { "separator" => ";" }
+        end
+
+        it "return an event from CSV data" do
+          codec.decode(data) do |event|
+            expect(event.get("column1")).to eq("big,bird")
+            expect(event.get("column2")).to eq("sesame street")
+          end
+        end
+      end
+
+      describe "quote char" do
+        let(:data) { "big,bird,'sesame street'" }
+
+        let(:config) do
+          { "quote_char" => "'"}
+        end
 
         it "return an event from CSV data" do
           codec.decode(data) do |event|
             expect(event.get("column1")).to eq("big")
             expect(event.get("column2")).to eq("bird")
-            expect(event.get("column3")).to eq("sesame, street")
+            expect(event.get("column3")).to eq("sesame street")
+          end
+        end
+
+        context "using the default one" do
+          let(:data) { 'big,bird,"sesame, street"' }
+          let(:config) { Hash.new }
+
+          it "return an event from CSV data" do
+            codec.decode(data) do |event|
+              expect(event.get("column1")).to eq("big")
+              expect(event.get("column2")).to eq("bird")
+              expect(event.get("column3")).to eq("sesame, street")
+            end
+          end
+        end
+
+        context "using a null" do
+          let(:data) { 'big,bird,"sesame" street' }
+          let(:config) do
+            { "quote_char" => "\x00" }
+          end
+
+          it "return an event from CSV data" do
+            codec.decode(data) do |event|
+              expect(event.get("column1")).to eq("big")
+              expect(event.get("column2")).to eq("bird")
+              expect(event.get("column3")).to eq('"sesame" street')
+            end
           end
         end
       end
 
-      context "using a null" do
-        let(:data) { 'big,bird,"sesame" street' }
-        let(:config) do
-          { "quote_char" => "\x00" }
+      describe "having headers" do
+
+        let(:data) do
+          [ "size,animal,movie", "big,bird,sesame street"]
         end
 
-        it "return an event from CSV data" do
-          codec.decode(data) do |event|
-            expect(event.get("column1")).to eq("big")
-            expect(event.get("column2")).to eq("bird")
-            expect(event.get("column3")).to eq('"sesame" street')
+        let(:new_data) do
+          [ "host,country,city", "example.com,germany,berlin"]
+        end
+
+        let(:config) do
+          { "autodetect_column_names" => true }
+        end
+
+        it "include header information when requested" do
+          codec.decode(data[0]) # Read the headers
+          codec.decode(data[1]) do |event|
+            expect(event.get("size")).to eq("big")
+            expect(event.get("animal")).to eq("bird")
+            expect(event.get("movie")).to eq("sesame street")
           end
         end
       end
-    end
 
-    describe "having headers" do
-
-      let(:data) do
-        [ "size,animal,movie", "big,bird,sesame street"]
-      end
-
-      let(:new_data) do
-        [ "host,country,city", "example.com,germany,berlin"]
-      end
-
-      let(:config) do
-        { "autodetect_column_names" => true }
-      end
-
-      it "include header information when requested" do
-        codec.decode(data[0]) # Read the headers
-        codec.decode(data[1]) do |event|
-          expect(event.get("size")).to eq("big")
-          expect(event.get("animal")).to eq("bird")
-          expect(event.get("movie")).to eq("sesame street")
-        end
-      end
-    end
-
-    describe "using field convertion" do
-
-      let(:config) do
-        { "convert" => { "column1" => "integer", "column3" => "boolean" } }
-      end
-      let(:data)   { "1234,bird,false" }
-
-      it "get converted values to the expected type" do
-        codec.decode(data) do |event|        
-          expect(event.get("column1")).to eq(1234)
-          expect(event.get("column2")).to eq("bird")
-          expect(event.get("column3")).to eq(false)
-        end
-      end
-
-      context "when using column names" do
+      describe "using field conversion" do
 
         let(:config) do
-          { "convert" => { "custom1" => "integer", "custom3" => "boolean" },
-            "columns" => ["custom1", "custom2", "custom3"] }
+          { "convert" => { "column1" => "integer", "column3" => "boolean" } }
         end
+        let(:data)   { "1234,bird,false" }
 
         it "get converted values to the expected type" do
           codec.decode(data) do |event|
-            expect(event.get("custom1")).to eq(1234)
-            expect(event.get("custom2")).to eq("bird")
-            expect(event.get("custom3")).to eq(false)
+            expect(event.get("column1")).to eq(1234)
+            expect(event.get("column2")).to eq("bird")
+            expect(event.get("column3")).to eq(false)
+          end
+        end
+
+        context "when using column names" do
+
+          let(:config) do
+            { "convert" => { "custom1" => "integer", "custom3" => "boolean" },
+              "columns" => ["custom1", "custom2", "custom3"] }
+          end
+
+          it "get converted values to the expected type" do
+            codec.decode(data) do |event|
+              expect(event.get("custom1")).to eq(1234)
+              expect(event.get("custom2")).to eq("bird")
+              expect(event.get("custom3")).to eq(false)
+            end
           end
         end
       end
+
+      context "with target" do
+
+        let(:config) { super().merge('target' => '[csv-root]', 'ecs_compatibility' => ecs_select.active_mode.to_s) }
+
+        it "return an event from CSV data" do
+          event_count = 0
+          codec.decode(data) do |event|
+            event_count += 1
+            expect( event.include?("column1") ).to be false
+            expect( event.get("csv-root") ).to eql('column1' => 'big', 'column2' => 'bird', 'column3' => "sesame street")
+          end
+          expect( event_count ).to eql 1
+        end
+
+        it 'set event.original in ECS mode' do
+          codec.decode(data) do |event|
+            if ecs_select.active_mode == :disabled
+              expect( event.get("[event][original]") ).to be nil
+            else
+              expect( event.get("[event][original]") ).to eql data
+            end
+          end
+        end
+
+      end
     end
+
   end
 
   describe "encode" do

--- a/spec/codecs/csv_spec.rb
+++ b/spec/codecs/csv_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"
 require "logstash/codecs/csv"
-require "logstash/event"
+
 require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 
 describe LogStash::Codecs::CSV, :ecs_compatibility_support do
@@ -17,10 +18,6 @@ describe LogStash::Codecs::CSV, :ecs_compatibility_support do
     let(:data) { "big,bird,sesame street" }
 
     ecs_compatibility_matrix(:disabled, :v1, :v8 => :v1) do |ecs_select|
-
-      # before(:each) do
-      #   allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
-      # end
 
       it "return an event from CSV data" do
         event_count = 0


### PR DESCRIPTION
We're introducing a `target => ...` configuration option for the codec, to aid ECS support.
When `target` isn't set in ECS mode, we do the usual [info log message](https://github.com/logstash-plugins/logstash-mixin-ecs_compatibility_support/pull/6).
